### PR TITLE
Update TS types location to comply with `moduleResolution: bundler`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "exports": {
     "import": "./dist/esm/index.js",
     "require": "./dist/cjs/index.js",
-    "default": "./dist/esm/index.js"
+    "default": "./dist/esm/index.js",
+    "types": "./dist/types/index.d.ts"
   },
   "files": [
     "src/**/*",


### PR DESCRIPTION
One nitpick of Typescript is that if `moduleResolution` is set to `bundler` in `tsconfig.json`, it will only read what's in the `exports` property of `package.json`.

This change adds the types location to `exports`.