### PR TITLE
Fix types resolution for esm and cjs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,24 +10,32 @@
   },
   "author": "Viktor Qvarfordt",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "types": "./dist/types/index.d.ts",
+  "module": "./dist/esm/index.mjs",
+  "types": "./dist/cjs/index.d.ts",
   "exports": {
-    "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.js",
-    "default": "./dist/esm/index.js",
-    "types": "./dist/types/index.d.ts"
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.mts",
+        "default": "./dist/esm/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    }
   },
   "files": [
     "src/**/*",
     "dist/**/*.js",
+    "dist/**/*.mjs",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
+    "dist/**/*.d.mts",
     "dist/**/*.d.ts.map"
   ],
   "scripts": {
     "clean": "rm -rf dist",
-    "build": "tsc & tsc --project tsconfig.cjs.json",
+    "build": "yarn clean && tsc && tsc --project tsconfig.cjs.json && find dist/esm/ -name \"*.js\" -execdir bash -c 'mv \"$1\" \"${1%.js}.mjs\"' - '{}' \\; && mv ./dist/esm/index.d.ts ./dist/esm/index.d.mts",
     "watch": "tsc-watch --onSuccess \"yalc push\""
   },
   "peerDependencies": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,2 @@
-export { autoTextSize, updateTextSize } from "./auto-text-size-standalone";
-export { AutoTextSize } from "./auto-text-size-react";
+export { autoTextSize, updateTextSize } from "./auto-text-size-standalone.js";
+export { AutoTextSize } from "./auto-text-size-react.js";

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -2,9 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
-    "declaration": false,
-    "declarationMap": false,
-    "declarationDir": null,
+    "declarationDir": "dist/cjs",
     "outDir": "dist/cjs"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,11 @@
   "compilerOptions": {
     "target": "esnext",
     "lib": ["dom"],
-    
+
     "module": "esnext",
     "declaration": true,
     "declarationMap": true,
-    "declarationDir": "dist/types",
+    "declarationDir": "dist/esm",
     "outDir": "dist/esm",
 
     "sourceMap": true,
@@ -28,5 +28,5 @@
     "incremental": true,
     "jsx": "react"
   },
-  "include": ["src"],
+  "include": ["src"]
 }


### PR DESCRIPTION
Fix `exports` property in package.json so declaration files are split between `import` and `require`.

Add extension to imported files so they can be imported in ESM and CJS mode. See https://www.typescriptlang.org/docs/handbook/esm-node.html

Add script to package.json to rename ESM files so they are not mislabed as CJS files.