### PR TITLE
Change compilation target to ES6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "ES6",
     "lib": ["dom"],
 
     "module": "esnext",


### PR DESCRIPTION
I've got an error when trying to use the package using a custom webpack build: 

![image](https://github.com/sanalabs/auto-text-size/assets/11337615/95e68aa1-eb2c-4dad-b5f1-179815c1963e)

Luckly, the error is pretty simple to resolve, we just need to change the `target` on `tsconfig.json` to transpile the optional chaining that was erroring.