### PR TITLE
Add `boxoneline` mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ The text fills both the width and the height of the container, allowing wrapping
 
 <img src="https://raw.githubusercontent.com/sanalabs/auto-text-size/main/example/imgs/box-mode.gif" width="300" />
 
+## Boxoneline mode
+
+The text fills both the width and the height of the container, without wrapping to multiple lines.
+
+
 ## React component
 
 The `AutoTextSize` component automatically re-runs when `children` changes and when the element resizes.
@@ -42,13 +47,13 @@ export const Title = ({ text }) => {
 
 ### `AutoTextSize` props
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| `mode` | `'oneline' \|  'multiline' \| 'box` | `'multiline'` | Determine how text will wrap. |
-| `minFontSizePx` | `number` | `8` | The minimum font size to be used. |
-| `maxFontSizePx` | `number` | `160` | The maximum font size to be used. |
-| `fontSizePrecisionPx` | `number` | `0.1` | The algorithm stops when reaching the precision. |
-| `as` | `string \| ReactComponent` | `'div'` | The underlying component that `AutoTextSize` will use. |
+| Name | Type                                                 | Default | Description |
+| --- |------------------------------------------------------| --- | --- |
+| `mode` | `'oneline' \|  'multiline' \| 'box' \| 'boxoneline` | `'multiline'` | Determine how text will wrap. |
+| `minFontSizePx` | `number`                                             | `8` | The minimum font size to be used. |
+| `maxFontSizePx` | `number`                                             | `160` | The maximum font size to be used. |
+| `fontSizePrecisionPx` | `number`                                             | `0.1` | The algorithm stops when reaching the precision. |
+| `as` | `string \| ReactComponent`                           | `'div'` | The underlying component that `AutoTextSize` will use. |
 
 ## Vanilla function
 
@@ -79,14 +84,14 @@ updateTextSize(options)
 
 ### `autoTextSize` options
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| `innerEl` | `HTMLElement` | | The inner element to be auto sized. |
-| `containerEl` | `HTMLElement` | | The container element defines the dimensions. |
-| `mode` | `'oneline' \|  'multiline' \| 'box` | `'multiline'` | Determine how text will wrap. |
-| `minFontSizePx` | `number` | `8` | The minimum font size to be used. |
-| `maxFontSizePx` | `number` | `160` | The maximum font size to be used. |
-| `fontSizePrecisionPx` | `number` | `0.1` | The algorithm stops when reaching the precision. |
+| Name | Type                                                | Default | Description |
+| --- |-----------------------------------------------------| --- | --- |
+| `innerEl` | `HTMLElement`                                       | | The inner element to be auto sized. |
+| `containerEl` | `HTMLElement`                                       | | The container element defines the dimensions. |
+| `mode` | `'oneline' \|  'multiline' \| 'box' \| 'boxoneline'` | `'multiline'` | Determine how text will wrap. |
+| `minFontSizePx` | `number`                                            | `8` | The minimum font size to be used. |
+| `maxFontSizePx` | `number`                                            | `160` | The maximum font size to be used. |
+| `fontSizePrecisionPx` | `number`                                            | `0.1` | The algorithm stops when reaching the precision. |
 
 ## Details
 

--- a/src/auto-text-size-standalone.ts
+++ b/src/auto-text-size-standalone.ts
@@ -192,7 +192,7 @@ const boxAlgo = ({
 };
 
 export type Options = {
-  mode?: "oneline" | "multiline" | "box" | undefined;
+  mode?: "oneline" | "multiline" | "box" | "boxoneline" | undefined;
   minFontSizePx?: number | undefined;
   maxFontSizePx?: number | undefined;
   fontSizePrecisionPx?: number | undefined;
@@ -254,6 +254,8 @@ export function updateTextSize({
   } else if (mode === "box") {
     innerStyles.whiteSpace = "pre-wrap";
     innerStyles.wordBreak = "break-word";
+  } else if (mode === "boxoneline") {
+    innerStyles.whiteSpace = "nowrap";
   }
 
   Object.assign(containerEl.style, containerStyles);
@@ -297,6 +299,8 @@ export function updateTextSize({
   } else if (mode === "multiline") {
     multilineAlgo(algoOpts);
   } else if (mode === "box") {
+    boxAlgo(algoOpts);
+  } else if (mode === "boxoneline") {
     boxAlgo(algoOpts);
   }
 }


### PR DESCRIPTION
This adds a new mode similar to `box`, but constraining the contents to remain on a single line of text.